### PR TITLE
Fix Nether portals not vanishing when frame destroyed

### DIFF
--- a/src/com/mccraftaholics/warpportals/bukkit/BukkitEventListener.java
+++ b/src/com/mccraftaholics/warpportals/bukkit/BukkitEventListener.java
@@ -163,7 +163,7 @@ public class BukkitEventListener implements Listener {
 	 */
 	@EventHandler
 	public void onBlockPhysicsEvent(BlockPhysicsEvent e) {
-		if (e.getBlock().getType() == Material.PORTAL) {
+		if (e.getBlock().getType() == Material.PORTAL && e.getChangedType() != Material.OBSIDIAN) {
 			e.setCancelled(true);
 		}
 	}


### PR DESCRIPTION
**The issue:**
In the current build of this plugin, players are not able to destroy nether portals since when they destroy any part of the Obsidian frame, the Portal blocks don't vanish. (Vanilla/Spigot behaviour: Portal disappears when Obsidian destroyed) However, admins may wish to run this plugin on a server which allows normal players to destroy native Nether portals. (I had players complain about this)
**PR Breakdown:**
This PR adds an extra check to the `BlockPhysicsEvent` handler which makes sure that we don't cancel physics events caused by Obsidian blocks (aka. native Nether portals being destroyed).
**Potential problems:**
Although this resolves the issue for me, it might be better to check whether the event was fired for an actual WarpPortal block instead.
**Testing materials:**
I have tested that this change resolves mentioned issue and this is also running in a Production environment. However, I have **not** tested whether this change affects the initial behaviour of the `BlockPhysicsEvent` handler. (It's 5am now, I can do this later if desired and if I get a full explanation what it's supposed to do - I didn't quite get that)
Find the artifact I'm currently running [here](http://www.minotopia.me/misc/warpportals_pr.jar).

Thanks!
