### PR TITLE
Disable metrics-lite

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,12 +28,6 @@
             <version>1.8-R0.1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mcstats.bukkit</groupId>
-            <artifactId>metrics-lite</artifactId>
-            <version>R7</version>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/mccraftaholics/warpportals/bukkit/PortalPlugin.java
+++ b/src/main/java/com/mccraftaholics/warpportals/bukkit/PortalPlugin.java
@@ -12,7 +12,6 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.mcstats.MetricsLite;
 
 import com.mccraftaholics.warpportals.helpers.Utils;
 import com.mccraftaholics.warpportals.manager.PortalManager;
@@ -35,21 +34,11 @@ public class PortalPlugin extends JavaPlugin {
 		mPortalManager = new PortalManager(getLogger(), mPortalConfig, mPortalDataFile, this);
 		mCommandHandler = new CommandHandler(this, mPortalManager, mPortalConfig);
 		getServer().getPluginManager().registerEvents(new BukkitEventListener(this, mPortalManager, mPortalConfig), this);
-		initMCStats();
 
 		// Register example WarpPortals Event API Listener
 		String tpMessage = mPortalConfig.getString("portals.teleport.message", Defaults.TP_MESSAGE);
 		ChatColor tpChatColor = ChatColor.getByChar(mPortalConfig.getString("portals.teleport.messageColor", Defaults.TP_MSG_COLOR));
 		getServer().getPluginManager().registerEvents(new WarpPortalsEventListener(tpMessage, tpChatColor), this);
-	}
-
-	private void initMCStats() {
-		try {
-			MetricsLite metrics = new MetricsLite(this);
-			metrics.start();
-		} catch (IOException e) {
-			// Failed to submit the stats :-(
-		}
 	}
 
 	private void initiateConfigFiles() {


### PR DESCRIPTION
I got some errors when using the WarpPortal plugin:

> [16:35:55] [Craft Scheduler Thread - 8/WARN]: [WarpPortals] Plugin WarpPortals v5.6.3 generated an exception while executing task 19
java.lang.NoSuchMethodError: org.bukkit.Server.getOnlinePlayers()[Lorg/bukkit/entity/Player;
        at com.mccraftaholics.warpportals.MetricsLite.postPlugin(MetricsLite.java:287) ~[?:?]
        at com.mccraftaholics.warpportals.MetricsLite.access$200(MetricsLite.java:53) ~[?:?]
        at com.mccraftaholics.warpportals.MetricsLite$1.run(MetricsLite.java:175) ~[?:?]
        at org.bukkit.craftbukkit.v1_12_R1.scheduler.CraftTask.run(CraftTask.java:71) ~[spigot-1.12.1.jar:git-Spigot-5340a52-e1f296d]
        at org.bukkit.craftbukkit.v1_12_R1.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:52) [spigot-1.12.1.jar:git-Spigot-5340a52-e1f296d]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_144]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_144]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]

It seems like the metrics-lite project is not available/maintained anymore and therefore outdated...
If you remove this dependency you get rid of the error messages.